### PR TITLE
Add biography page with nav link

### DIFF
--- a/biography.html
+++ b/biography.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Biography - Max Moser</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <div class="logo">MAX MOSER</div>
+    <nav>
+      <a href="biography.html">biography</a>
+      <a href="index.html#publications">publications</a>
+      <a href="index.html#contact">contact</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="bio-hero">
+      <h1 class="bio-page-title">Who I Am</h1>
+    </section>
+
+    <section class="bio-section">
+      <p>Max Moser is a mixed-methods social scientist working at the intersection of qualitative research and advanced data analytics. His work spans evidence synthesis, multilevel modelling and interpretive inquiry to help organisations understand people in context.</p>
+      <p>He has led large scale systematic reviews, designed and analysed surveys, and conducted in-depth interviews across a range of policy and clinical topics. Max combines rigorous statistical techniques with an appreciation of the lived experience behind the numbers.</p>
+      <p>When not analysing data, Max teaches research methods and writes about how psychology and culture shape decision making.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-left">
+      <div class="footer-logo">MAX MOSER</div>
+      <ul>
+        <li><a href="biography.html">who I am</a></li>
+        <li><a href="index.html#help">projects</a></li>
+        <li><a href="index.html#publications">contact</a></li>
+      </ul>
+    </div>
+    <div class="footer-middle">
+      <p><strong>E-mail</strong> <a href="mailto:max@example.com">max@example.com</a></p>
+      <p><strong>Telephone</strong> +44 (0) 7911 123 456</p>
+    </div>
+    <div class="footer-right">
+      <ul>
+        <li><a href="#">LinkedIn</a></li>
+        <li><a href="#">Twitter</a></li>
+        <li><a href="#">Instagram</a></li>
+      </ul>
+    </div>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <header>
     <div class="logo">MAX MOSER</div>
     <nav>
-      <a href="#biography">biography</a>
+      <a href="biography.html">biography</a>
       <a href="#publications">publications</a>
       <a href="#contact">contact</a>
     </nav>
@@ -71,7 +71,7 @@
     <div class="footer-left">
       <div class="footer-logo">MAX MOSER</div>
       <ul>
-        <li><a href="#biography">who I am</a></li>
+        <li><a href="biography.html">who I am</a></li>
         <li><a href="#help">projects</a></li>
         <li><a href="#publications">contact</a></li>
       </ul>

--- a/style.css
+++ b/style.css
@@ -217,3 +217,24 @@ footer {
 .footer a:hover {
   text-decoration: underline;
 }
+
+/* Biography page styles */
+.bio-hero {
+  background: linear-gradient(to right, #fceae8, #f1f1f1);
+  padding: 6rem 2rem;
+  text-align: center;
+}
+
+.bio-page-title {
+  font-size: 3rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.bio-section {
+  max-width: 800px;
+  margin: 3rem auto;
+  padding: 0 2rem;
+  font-size: 1.1rem;
+  line-height: 1.7;
+}


### PR DESCRIPTION
## Summary
- add dedicated biography page
- style biography page sections
- link the new page in the header and footer navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bdcf541e0832087deb35e1288037e