### PR TITLE
Update font in help section

### DIFF
--- a/style.css
+++ b/style.css
@@ -150,6 +150,7 @@ nav a {
 .help-item p {
   font-size: 1rem;
   line-height: 1.6;
+  font-family: 'Times New Roman', Times, serif;
 }
 
 .publications {


### PR DESCRIPTION
## Summary
- style `.help-item p` using Times New Roman so the body of the *How I Can Help* section uses that font

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686bf4b4b180832092e4c22dafae2754