### PR TITLE
Fix publication section overlap at smaller widths

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,7 +44,7 @@ nav a {
 
 .snap-section {
   scroll-snap-align: start;
-  height: 100vh;
+  min-height: 100vh;
 }
 
 .hero {


### PR DESCRIPTION
## Summary
- ensure snap sections can expand beyond the viewport height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d206db5c48320a0307fb4f0cdf569